### PR TITLE
Bump `crossbeam-queue` to 0.3.5 to fix CVE-2022-23639

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ appveyor = { repository = "QuietMisdreavus/synchronoise" }
 maintenance = { status = "as-is" }
 
 [dependencies]
-crossbeam-queue = "0.1"
+crossbeam-queue = "0.3.5"

--- a/src/event.rs
+++ b/src/event.rs
@@ -98,7 +98,7 @@ impl CountdownEvent {
     pub fn reset(&mut self) {
         self.counter = AtomicUsize::new(self.initial);
         // there shouldn't be any remaining thread handles in here, but let's clear it out anyway
-        while let Ok(thread) = self.waiting.pop() {
+        while let Some(thread) = self.waiting.pop() {
             thread.unpark();
         }
     }
@@ -181,7 +181,7 @@ impl CountdownEvent {
         }
 
         if current == 0 {
-            while let Ok(thread) = self.waiting.pop() {
+            while let Some(thread) = self.waiting.pop() {
                 thread.unpark();
             }
             Ok(true)
@@ -490,7 +490,7 @@ impl SignalEvent {
             // the reset signal and push their handle back in
             SignalKind::Auto => {
                 while self.signal.load(Ordering::SeqCst) {
-                    if let Ok(thread) = self.waiting.pop() {
+                    if let Some(thread) = self.waiting.pop() {
                         thread.unpark();
                     } else {
                         break;
@@ -499,7 +499,7 @@ impl SignalEvent {
             }
             // for manual resets, just unilaterally drain the queue
             SignalKind::Manual => {
-                while let Ok(thread) = self.waiting.pop() {
+                while let Some(thread) = self.waiting.pop() {
                     thread.unpark();
                 }
             }


### PR DESCRIPTION
This is a fix for the CVE-2022-23639 which has been fixed in https://github.com/crossbeam-rs/crossbeam/pull/781. I bumped the `crossbeam-queue` to `0.3.5` and fixed the other deprecation warning from the Rust standard library.

I am not very confident about my fix for the `compare_and_swap` and `compare_exchange`, if you want to take a look at something, please make sure that it is correct. I simply followed [the small migration guide that is on the documentation](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#migrating-to-compare_exchange-and-compare_exchange_weak). The tests are passing but, that is maybe not enough.

I think it could be great and non-breaking to bump the patch very of this crate, what do you think?

Thank you for your time 🏖️ 